### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo 
+        uses: actions/checkout@v4
+
+      - name: Update rust
+        run: |
+          rustup default nightly
+          rustup update
+          rustc --version
+          cargo --version
+
+      - name: Build pleep-search
+        run: cargo build --release --bin pleep-search
+      
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "target/release/pleep-search"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
-      - name: Checkout repo 
+      - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Update rust
@@ -20,7 +24,7 @@ jobs:
 
       - name: Build pleep-search
         run: cargo build --release --bin pleep-search
-      
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Cherry pick of baa8efc (main's CI commit) and a fix to make :white_check_mark: 

Whenever you feel like moving the `latest` tag, you'd do this:
```
git tag -fa latest
git push --force --tags
```

Example run (first tag): https://github.com/jameshi16/pleep/actions/runs/9982088908
Example run (retag): https://github.com/jameshi16/pleep/actions/runs/9982122269

Current release on my fork is the executable from the  retagged run